### PR TITLE
Uniform styles for SignIn & SignUp, global styles for inputs

### DIFF
--- a/buddy-app/components/SignIn.js
+++ b/buddy-app/components/SignIn.js
@@ -61,30 +61,30 @@ const SignIn = props => {
   if(!isLoading) {
     return (
     <KeyboardAwareScrollView contentContainerStyle={{ flex: 1 }}>
-      <View style={styles.screen}>
+      <View style={Global.container}>
         <View style={Global.logoContainer}>
           <Text style={Global.logo}>BUDDY</Text>
         </View>
-        <View style={styles.signInContainer}>
-          <Text style={styles.pageTitle}>Sign In</Text>
+          <Text style={Global.title}>Sign In</Text>
+          <View style={Global.formContainer}>
           <TextInput
-            style={styles.input}
+            style={Global.input}
             placeholder="Email"
             onChangeText={e => changeHandler(e, "email")}
             value={info.email}
             autoCapitalize="none"
           />
           <TextInput
-            style={styles.input}
+            style={Global.input}
             placeholder="Password"
             onChangeText={e => changeHandler(e, "password")}
             value={info.password}
             autoCapitalize="none"
             secureTextEntry
           />
-          <View style={styles.redirectContainer}>
-            <Text style={styles.redirect}>
-              Don't have an account yet? Sign Up (ADD LINK)
+          <View style={styles.fakeLinkContainer}>
+            <Text style={styles.fakeLink} onPress={() => {props.navigation.navigate("SignUp")}}>
+              Don't have an account yet? Sign Up
             </Text>
           </View>
           <View style={Buttons.container}>
@@ -108,37 +108,6 @@ const SignIn = props => {
 };
 
 const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    paddingHorizontal: 30,
-    width: "100%",
-    marginTop: 55,
-    alignItems: 'flex-start',
-  },
-  signInContainer: {
-    marginTop: 60
-  },
-  pageTitle: {
-    fontSize: 30,
-    color: "#2E2F38",
-    fontFamily: "Nunito-Regular",
-    marginBottom: 30
-  },
-  input: {
-    marginVertical: 10,
-    width: 350,
-    padding: 8,
-    borderWidth: 0.5,
-    borderColor: "#2E2F38",
-  },
-  redirectContainer: {
-    width: "100%",
-    alignItems: "center"
-  },
-  redirect: {
-    fontSize: 15,
-    fontFamily: "Nunito-Light"
-  },
   bottomNav: {
     backgroundColor: "#6d6dff",
     height: 96,
@@ -146,6 +115,15 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0
+  },
+  fakeLink: {
+    color: '#6D6DFF',
+    textDecorationLine: 'underline',
+    fontSize: 15,
+    fontFamily: "Nunito-Light"
+  },
+  fakeLinkContainer: {
+    alignSelf: 'center'
   }
 });
 

--- a/buddy-app/components/SignUp.js
+++ b/buddy-app/components/SignUp.js
@@ -25,48 +25,47 @@ export default class SignUp extends React.Component {
       <KeyboardAwareScrollView
         enableOnAndroid
         contentContainerStyle={{ flex: 1 }}>
-        <View style={su_styles.container}>
+        <View style={Global.container}>
           <View style={Global.logoContainer}>
             <Text style={Global.logo}>BUDDY</Text>
           </View>
 
-          <Text style={su_styles.signUp}>Sign Up</Text>
+          <Text style={Global.title}>Sign Up</Text>
 
-          <View style={su_styles.form}>
+          <View style={Global.formContainer}>
             <View style={su_styles.name}>
               <TextInput
                 placeholder="First Name"
                 onChangeText={text => this.handleChange(text, 'first_name')}
-                style={su_styles.first}
+                style={[Global.input,{ width: '45%'}]}
               />
               <TextInput
                 placeholder="Last Name"
                 onChangeText={text => this.handleChange(text, 'last_name')}
-                style={su_styles.last}
+                style={[Global.input,{ width: '45%'}]}
               />
             </View>
 
             <TextInput
               placeholder="Email"
               onChangeText={text => this.handleChange(text, 'email')}
-              style={su_styles.input}
+              style={Global.input}
               autoCapitalize="none"
             />
             <TextInput
               placeholder="Password"
               onChangeText={text => this.handleChange(text, 'password')}
-              style={su_styles.input}
+              style={Global.input}
               autoCapitalize="none"
             />
             <TextInput
               placeholder="Location"
               onChangeText={text => this.handleChange(text, 'location')}
-              style={su_styles.input}
+              style={Global.input}
             />
           </View>
 
           <View style={Buttons.container}>
-
             <TouchableOpacity onPress={() => this.props.navigation.navigate('Landing')}>
               <Text style={[Buttons.text,Buttons.textAuth]}>Cancel</Text>
             </TouchableOpacity>
@@ -74,9 +73,9 @@ export default class SignUp extends React.Component {
               style={[Buttons.btn,Buttons.primary,{ width: 130 }]}
             >
               <Text style={[Buttons.text,Buttons.textAuth,Buttons.textPrimary]}>Sign Up</Text>
-            </TouchableOpacity>
-          
+            </TouchableOpacity>         
           </View>
+          <View style={su_styles.bottomNav}></View>
         </View>
       </KeyboardAwareScrollView>
     );
@@ -84,49 +83,16 @@ export default class SignUp extends React.Component {
 }
 
 const su_styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    paddingHorizontal: 30,
-    width: '100%',
-    marginTop: 55,
-    alignItems: 'flex-start',
-  },
-  form: {
-    height: 300,
-    display: 'flex',
-    justifyContent: 'space-evenly',
-  },
-  input: {
-    borderColor: '#d6d7da',
-    borderWidth: 1.2,
-    width: 350,
-    height: 45,
-    paddingLeft: 10,
-  },
-  signUp: {
-    marginTop: 60,
-    fontSize: 30,
-    color: "#2E2F38",
-    fontFamily: "Nunito-Regular",
-    marginBottom: 30,
-  },
   name: {
     flexDirection: 'row',
     justifyContent: 'space-between',
   },
-  first: {
-    width: 167,
-    height: 45,
-    borderColor: '#d6d7da',
-    borderWidth: 1.2,
-    paddingLeft: 10,
-  },
-  last: {
-    width: 167,
-    height: 45,
-    borderColor: '#d6d7da',
-    borderWidth: 1.2,
-    textAlign: 'left',
-    paddingLeft: 10,
-  },
+  bottomNav: {
+    backgroundColor: "#6d6dff",
+    height: 96,
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0
+  }
 });

--- a/buddy-app/styles/Buttons.js
+++ b/buddy-app/styles/Buttons.js
@@ -5,8 +5,9 @@ const Buttons = StyleSheet.create({
     btn: {
         justifyContent: 'center',
         alignItems: 'center',
-        paddingVertical: 10,
         paddingHorizontal: 30,
+        width: 130,
+        height: 40
     },
     text: {
         fontSize: 15,

--- a/buddy-app/styles/Global.js
+++ b/buddy-app/styles/Global.js
@@ -11,6 +11,33 @@ const Global = StyleSheet.create({
         borderBottomWidth: 5,
         borderBottomColor: 'black',
     },
+    title: {
+        marginTop: 60,
+        fontSize: 30,
+        color: Colors.darkGray,
+        fontFamily: 'Nunito-Regular',
+    },
+    container: {
+        flex: 1,
+        paddingHorizontal: 30,
+        width: '100%',
+        marginTop: 55,
+        alignItems: 'flex-start',
+    },
+    formContainer: {
+        width: '100%',
+        marginTop: 30,
+    },
+    input: {
+        borderColor: Colors.lightGray,
+        borderWidth: 1,
+        width: '100%',
+        height: 40,
+        paddingLeft: 10,
+        marginBottom: 20,
+        fontSize: 15,
+    },
+    
 })
 
-export default Global
+export default Global;

--- a/buddy-app/styles/Global.js
+++ b/buddy-app/styles/Global.js
@@ -36,6 +36,7 @@ const Global = StyleSheet.create({
         paddingLeft: 10,
         marginBottom: 20,
         fontSize: 15,
+        fontFamily: 'Nunito-Light'
     },
     
 })


### PR DESCRIPTION
# Description

Styles for **SignUp** and **SignIn** are refactored and have been moved to Global StyleSheet. Needs to be tested on Android.

**Landing** remains dependent on the StyleSheet in the component itself.
SignUp and SignIn also retain their StyleSheets for minor, a la carte tweaks.
The nav bar is not global yet, since the Dashboard design is a work in progress.

Thanks!

## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [X] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] iPhone 7 Plus

