### PR TITLE
[DEMO] react navigation implementation

### DIFF
--- a/buddy-app/components/ActivityCard.js
+++ b/buddy-app/components/ActivityCard.js
@@ -38,11 +38,11 @@ export default function ActivityCard(props) {
           </Text>
         </TouchableOpacity>
       </View>
-      <EditActivity
+      {/* <EditActivity
         activity={activity}
         isModalVisible={isModalVisible}
         toggleModal={toggleModal}
-      />
+      /> */}
     </View>
   );
 }

--- a/buddy-app/components/AppNavigator.js
+++ b/buddy-app/components/AppNavigator.js
@@ -1,42 +1,101 @@
 import React from "react";
-import { createAppContainer } from "react-navigation";
+import { ActivityIndicator, AsyncStorage, View } from "react-native";
+import { createAppContainer, createSwitchNavigator } from "react-navigation";
+import { createBottomTabNavigator } from "react-navigation-tabs";
 import { createStackNavigator } from "react-navigation-stack";
+import { Feather } from "@expo/vector-icons";
 
 // components
 import Landing from "./Landing";
 import SignUp from "./SignUp";
 import SignIn from "./SignIn";
-import AuthStack from "./AuthStack";
 import InterestOnboard from "./InterestsOnboard";
 import Dashboard from "./Dashboard";
 import Profile from "./Profile";
-const AppNavigator = createStackNavigator(
+
+class AuthLoadingScreen extends React.Component {
+  componentDidMount() {
+    this._bootstrapAsync();
+  }
+  _bootstrapAsync = async () => {
+    const userToken = await AsyncStorage.getItem("@token");
+    // Fetch token from storage
+    if (!userToken) {
+      await AsyncStorage.clear();
+    }
+    // This will switch to the App screen or Auth screen and this loading
+    // screen will be unmounted and thrown away.
+    this.props.navigation.navigate(userToken ? "App" : "Auth");
+  };
+
+  // Render any loading content that you like here
+  render() {
+    return (
+      <View>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+}
+
+const AppStack = createBottomTabNavigator(
   {
-    Landing: {
-      screen: Landing
-    },
-    SignUp: {
-      screen: SignUp
-    },
-    SignIn: {
-      screen: SignIn
-    },
-    AuthStack: {
-      screen: AuthStack
-    },
-    InterestOnboard: {
-      screen: InterestOnboard
-    },
     Dashboard: {
-      screen: Dashboard
+      screen: Dashboard,
+      navigationOptions: {
+        header: null,
+        tabBarIcon: ({ tintColor, focused }) => (
+          <Feather name="home" size={focused ? 35 : 30} color={tintColor} />
+        )
+      }
     },
     Profile: {
-      screen: Profile
+      screen: Profile,
+      navigationOptions: {
+        header: null,
+        tabBarIcon: ({ tintColor, focused }) => (
+          <Feather name="user" size={focused ? 35 : 30} color={tintColor} />
+        )
+      }
     }
   },
   {
-    initialRouteName: "Landing",
-    headerMode: "none"
+    initialRouteName: "Dashboard",
+    tabBarOptions: {
+      showIcon: true,
+      showLabel: false,
+      activeTintColor: "#FFF",
+      activeBackgroundColor: "#9798ff",
+      inactiveTintColor: "#B0B0B0",
+      inactiveBackgroundColor: "#6D6DFF",
+      tabStyle: {
+        borderRadius: 100 / 2,
+        marginHorizontal: "16%",
+        marginVertical: 10
+      },
+      style: {
+        height: 96,
+        backgroundColor: "#6D6DFF"
+      }
+    }
+  }
+);
+
+const AuthenticationStack = createStackNavigator({
+  Landing: Landing,
+  SignUp: SignUp,
+  SignIn: SignIn,
+  InterestOnboard: InterestOnboard
+});
+
+const AppNavigator = createSwitchNavigator(
+  {
+    AuthLoading: AuthLoadingScreen,
+    App: AppStack,
+    Auth: AuthenticationStack
+  },
+  {
+    initialRouteName: "AuthLoading"
   }
 );
 

--- a/buddy-app/components/Dashboard.js
+++ b/buddy-app/components/Dashboard.js
@@ -117,11 +117,11 @@ export const Dashboard = props => {
               return <ActivityCard activity={activity} key={activity.id} />;
             })}
 
-            <AddActivity isVisible={modalVisible} closeModal={closeModal} />
+            {/* <AddActivity isVisible={modalVisible} closeModal={closeModal} /> */}
           </View>
         </ScrollView>
       </View>
-      <NavBar />
+      {/*  <NavBar /> */}
     </View>
   );
 };

--- a/buddy-app/components/Profile.js
+++ b/buddy-app/components/Profile.js
@@ -31,7 +31,7 @@ const Profile = props => {
         <Text style={[Global.textNormal, { marginTop: 20 }]}>Sign Out</Text>
       </TouchableHighlight>
 
-      <NavBar />
+      {/* <NavBar /> */}
     </View>
   );
 };

--- a/buddy-app/package-lock.json
+++ b/buddy-app/package-lock.json
@@ -11249,6 +11249,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
       "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-native": {
       "version": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
       "integrity": "sha512-KBH8PlT3K3yTYW/u2E1KKTAaVq2WjYAqZTOgXyosSLwg/TVpG6JbHyTG4a24f5tI2GEqarRLufsggF4CkB7KUw==",
@@ -11456,6 +11461,11 @@
       "resolved": "https://registry.npmjs.org/react-native-select-input-ios/-/react-native-select-input-ios-2.0.2.tgz",
       "integrity": "sha512-18WrGCjxG4B6D5hRE79hJgYtyPEuMKfgOrEcdbb2aIirJN8pE0bq4kaZJJZ9OITGx48dR6FkSrDrnDdE1Bvs3g=="
     },
+    "react-native-tab-view": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-2.10.0.tgz",
+      "integrity": "sha512-qgexVz5eO4yaFjdkmn/sURXgVvaBo6pZD/q1eoca96SbPVbaH3WzVhF3bRUfeTHwZkXwznFTpS3JURqIFU8vQA=="
+    },
     "react-native-testing-library": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/react-native-testing-library/-/react-native-testing-library-1.11.1.tgz",
@@ -11546,6 +11556,27 @@
       "integrity": "sha512-dLyhLX0EM53grtsuzjl3azatCVr9ZdK/I/ZzW6c9GSqwXwFTJ+XL4z9kbIXoviMb9qXbLRpVhSR9eAlpsmPZUw==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-navigation-tabs": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-navigation-tabs/-/react-navigation-tabs-2.5.6.tgz",
+      "integrity": "sha512-4WivEAsChJ+MuJ6JHxhAUMekHnVIt/zc4y/07KChXD5NBkSE0sk4vmMRndZQ6AP3n/ZihACcfigBAsMoqt0JXA==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.0",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-native-safe-area-view": "^0.14.6",
+        "react-native-tab-view": "^2.9.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
       }
     },
     "react-proxy": {

--- a/buddy-app/package.json
+++ b/buddy-app/package.json
@@ -27,6 +27,7 @@
     "react-native-web": "^0.11.7",
     "react-navigation": "^4.0.10",
     "react-navigation-stack": "^1.10.2",
+    "react-navigation-tabs": "^2.5.6",
     "react-redux": "^7.1.1",
     "redux": "^4.0.4",
     "redux-mock-store": "^1.5.3",


### PR DESCRIPTION
# Description

Two navigation possibilities here, expanding our use of `react-navigation` in AppNavigator.js

This does not use AuthStack.js, so I had to disable the activity cards & modals (since the state stuff happening in AuthStack affects the rest of the Dashboard).

1. Switch Navigator: checks token and sends you to to Landing or Dashboard accordingly. Could be a good refactor for some useEffect hooks, provided that it plays nicely with redux and token finickiness.

2. Bottom Tab Navigator: Highlights active screen with a circle, uses true vector icons.

Fixes # (issue)
n/a

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] iPhone 7